### PR TITLE
메타 태그의 이미지 주소 앞에 유알엘 스킴 추가

### DIFF
--- a/tpl/index.html
+++ b/tpl/index.html
@@ -7,11 +7,11 @@
 <meta name="twitter:site" content="@xtendo_org_ko" />
 <meta name="twitter:title" content="\title\" />
 <meta name="twitter:description" content="하스켈은 고성능의 소프트웨어를 안전하고 효율적으로 만들 수 있게 해주는 현대적인 프로그래밍 언어입니다. 하스켈 모임은 함께 모여서 하스켈의 유용성과 프로그래밍의 즐거움을 탐사합니다." />
-<meta name="twitter:image" content="/static/img/kr-square-typo.png" />
+<meta name="twitter:image" content="https://haskell.kr/static/img/kr-square-typo.png" />
 <meta property="og:title" content="\title\" />
 <meta property="og:type" content="website" />
 <meta property="og:description" content="하스켈은 고성능의 소프트웨어를 안전하고 효율적으로 만들 수 있게 해주는 현대적인 프로그래밍 언어입니다. 하스켈 모임은 함께 모여서 하스켈의 유용성과 프로그래밍의 즐거움을 탐사합니다." />
-<meta property="og:image" content="/static/img/kr-square-typo.png" />
+<meta property="og:image" content="https://haskell.kr/static/img/kr-square-typo.png" />
 <meta property="og:image:width" content="300">
 <meta property="og:image:height" content="300">
 <meta property="og:image_type" content="image/png" />

--- a/tpl/main.html
+++ b/tpl/main.html
@@ -7,11 +7,11 @@
 <meta name="twitter:site" content="@xtendo_org_ko" />
 <meta name="twitter:title" content="\title\" />
 <meta name="twitter:description" content="하스켈은 고성능의 소프트웨어를 안전하고 효율적으로 만들 수 있게 해주는 현대적인 프로그래밍 언어입니다. 하스켈 모임은 함께 모여서 하스켈의 유용성과 프로그래밍의 즐거움을 탐사합니다." />
-<meta name="twitter:image" content="/static/img/kr-square-typo.png" />
+<meta name="twitter:image" content="https://haskell.kr/static/img/kr-square-typo.png" />
 <meta property="og:title" content="\title\" />
 <meta property="og:type" content="website" />
 <meta property="og:description" content="하스켈은 고성능의 소프트웨어를 안전하고 효율적으로 만들 수 있게 해주는 현대적인 프로그래밍 언어입니다. 하스켈 모임은 함께 모여서 하스켈의 유용성과 프로그래밍의 즐거움을 탐사합니다." />
-<meta property="og:image" content="/static/img/kr-square-typo.png" />
+<meta property="og:image" content="https://haskell.kr/static/img/kr-square-typo.png" />
 <meta property="og:image:width" content="300">
 <meta property="og:image:height" content="300">
 <meta property="og:image_type" content="image/png" />


### PR DESCRIPTION
자꾸 귀찮게 죄송합니다 (_ _)

페이스북 OpenGraph 디버거가 저건 유알엘 스킴이 아니라고 불평해서 일단 고쳐보긴 하는데, 이런다고 제대로 작동할지는 모르겠네요. 제 블로그도 정확히 저런식으로 되어 있는데 그건 잘 긁어오는걸로 봐선...  #4 에서 잠깐 언급했지만 트위터 카드는 또 별개의 문제인 것 같구요. (아마 제가 소유권자로 써놓은 @xtendo-org 님께서 Card Validator 에 들어가서 신청해야되는 것 같은..?) 그냥 이런 메타 태그들 넣지 말까 하는 생각도 들고요 😑
