### PR TITLE
"다음 모임"을 "지난 모임"으로 변경

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -2,7 +2,7 @@ title: 하스켈 모임
 template: index.html
 next: /meetup/2016-12-03
 
-## 다음 모임
+## 지난 모임
 
 - 2016년 12월 3일 토요일 13시
 - 스포카 서울 사무실


### PR DESCRIPTION
뭔가 모임을 했다는 흔적이 남으면서 사이트가 너무 방치되어보이지 않도록 고침.